### PR TITLE
fix timer to be exact

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -95,12 +95,11 @@ impl Timer {
     pub fn tick(&mut self) -> bool { // returns true if session finished
         if self.state == TimerState::Running {
             if let Some(last) = self.last_tick {
-                let elapsed = last.elapsed();
-                if elapsed >= Duration::from_secs(1) {
-                    if self.remaining_seconds > 0 {
-                        self.remaining_seconds -= 1;
-                    }
-                    self.last_tick = Some(Instant::now());
+                let elapsed_secs = last.elapsed().as_secs();
+                if elapsed_secs >= 1 {
+                    let decrement = elapsed_secs.min(self.remaining_seconds);
+                    self.remaining_seconds -= decrement;
+                    self.last_tick = Some(last + Duration::from_secs(elapsed_secs));
                     if self.remaining_seconds == 0 {
                         self.state = TimerState::Finished;
                         return true;


### PR DESCRIPTION
## Summary
Fix issue #5 
- Fix timer drift caused by losing fractional seconds on each tick
- Handle cases where multiple seconds elapse between tick calls

## Example
### Before:
If 1.3 seconds elapsed, we decremented by 1 but reset last_tick to now(), losing 0.3 seconds. Over a 25-minute focus session, this could add several minutes of drift.

### After:
Now we advance last_tick by exactly the elapsed seconds, preserving the fractional remainder for accurate timing.